### PR TITLE
Usacloudへbash-completionパッケージ追加

### DIFF
--- a/publicscript/Usacloud
+++ b/publicscript/Usacloud
@@ -17,8 +17,8 @@
 #  tk1v "tk1v"
 # @sacloud-select-end
 # @sacloud-apikey required permission=create AK "APIキー"
-# jq install
-yum install -y yum-utils
+# jq and bash-completion install
+yum install -y yum-utils bash-completion
 yum-config-manager --enable epel
 yum install -y jq
 # usacloud install


### PR DESCRIPTION
Usacloudスタートアップスクリプトに対し`bash-completion`パッケージのインストール処理を追加します。  
これにより、bash + usacloudコマンドにてTABキーでの入力補完機能が利用可能となります。