### PR TITLE
CentOSの初期設定スクリプトを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@
 | 監視 | [zabbix-agent](./publicscript/zabbix-agent.sh) | zabbix-serverに対応するエージェントzabbix-agentをインストールします。<br />本スクリプトの詳細は[マニュアル](https://cloud-news.sakura.ad.jp/startup-script/zabbix-agent/)を参照ください。<br />※CentOS7系のみで動作します |
 | 監視 | [hatohol-server](./publicscript/hatohol-server.sh) | 複数のzabbix-serverを統合管理するhatoholをインストールします。<br />※CentOS7系のみで動作します
 | セキュリティ | [Vuls](./publicscript/vuls.sh) | オープンソースで開発が進められているLinux/FreeBSD向けの脆弱性スキャンツールです。OSだけでなくミドルウェアやプログラム言語のライブラリなどもスキャンに対応しております。また、エージェントレスで実行させることが出来、SSH経由でリモートのサーバのスキャンを行うことも可能です。<br />※CentOS7系のみで動作します |
-
+| セキュリティ | [initial-setup](./publicscript/initial-setup) | CentOSの基本的な初期設定（ユーザ作成、suコマンドの制限、SSHの制限）をします。<br /> ※CentOS6またはCentOS7のみで動作します | 

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@
 | 監視 | [zabbix-agent](./publicscript/zabbix-agent.sh) | zabbix-serverに対応するエージェントzabbix-agentをインストールします。<br />本スクリプトの詳細は[マニュアル](https://cloud-news.sakura.ad.jp/startup-script/zabbix-agent/)を参照ください。<br />※CentOS7系のみで動作します |
 | 監視 | [hatohol-server](./publicscript/hatohol-server.sh) | 複数のzabbix-serverを統合管理するhatoholをインストールします。<br />※CentOS7系のみで動作します
 | セキュリティ | [Vuls](./publicscript/vuls.sh) | オープンソースで開発が進められているLinux/FreeBSD向けの脆弱性スキャンツールです。OSだけでなくミドルウェアやプログラム言語のライブラリなどもスキャンに対応しております。また、エージェントレスで実行させることが出来、SSH経由でリモートのサーバのスキャンを行うことも可能です。<br />※CentOS7系のみで動作します |
-| セキュリティ | [initial-setup](./publicscript/initial-setup) | CentOSの基本的な初期設定（ユーザ作成、suコマンドの制限、SSHの制限）をします。<br /> ※CentOS6またはCentOS7のみで動作します | 
+| セキュリティ | [initial-setup](./publicscript/initial-setup.sh) | CentOSの基本的な初期設定（ユーザ作成、suコマンドの制限、SSHの制限）をします。<br /> ※CentOS6またはCentOS7のみで動作します | 

--- a/publicscript/initial-setup.sh
+++ b/publicscript/initial-setup.sh
@@ -6,8 +6,16 @@
 # @sacloud-require-archive distro-centos distro-ver-6.*
 #
 # @sacloud-desc-begin
-#    Initial setup script for CentOS7.x or CentOS6.x
 #    CentOS 7.x or 6.xの初期設定をします
+#    * パッケージの最新化
+#    * 新規ユーザの作成
+#    * suコマンドの制限
+#      * suコマンドの実行可能ユーザ・グループを限定する
+#      * パスワード入力なしでsudoコマンドを利用可能にする
+#    * ssh接続の制限
+#      * rootユーザのsshログインを禁止する
+#      * 公開鍵認証のみ接続を許可する
+#    ※ fail2banによりログインできなくなる場合があります
 # @sacloud-desc-end
 #
 # @sacloud-text required shellarg maxlen=60 user_name "新規追加するユーザ名"

--- a/publicscript/initial-setup.sh
+++ b/publicscript/initial-setup.sh
@@ -21,10 +21,6 @@
 # @sacloud-text required shellarg maxlen=60 user_name "新規追加するユーザ名"
 # @sacloud-password required shellarg maxlen=60 user_pass "新規追加するユーザのパスワード"
 # @sacloud-textarea required shellarg maxlen=512 public_key "利用する公開鍵"
-# @sacloud-radios-begin required default=7 centos_version "CentOSのバージョン"
-#   7 "CentOS7.x系"
-#   6 "CentOS6.x系"
-# @sacloud-radios-end
 
 USER=@@@user_name@@@
 PW=@@@user_pass@@@
@@ -89,6 +85,7 @@ chown -R $USER:$USER /home/$USER/.ssh/
 
 
 # sshd service restart
+CENTOS_VERSION=$(cat /etc/redhat-release | sed -e 's/.*\s\([0-9]\)\..*/\1/')
 if [ $CENTOS_VERSION = "7" ]; then
   systemctl restart sshd
 elif [ $CENTOS_VERSION = "6" ]; then

--- a/publicscript/initial-setup.sh
+++ b/publicscript/initial-setup.sh
@@ -25,7 +25,6 @@
 USER=@@@user_name@@@
 PW=@@@user_pass@@@
 PUBKEY=@@@public_key@@@
-CENTOS_VERSION=@@@centos_version@@@
 
 # disable SELinux temporarily
 setenforce 0

--- a/publicscript/initial-setup.sh
+++ b/publicscript/initial-setup.sh
@@ -89,7 +89,7 @@ CENTOS_VERSION=$(cat /etc/redhat-release | sed -e 's/.*\s\([0-9]\)\..*/\1/')
 if [ $CENTOS_VERSION = "7" ]; then
   systemctl restart sshd
 elif [ $CENTOS_VERSION = "6" ]; then
-  /etc/rc.d/init.d/sshd restart
+  service sshd restart
 fi
 
 exit 0

--- a/publicscript/initial-setup.sh
+++ b/publicscript/initial-setup.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# @sacloud-once
+#
+# @sacloud-require-archive distro-centos distro-ver-7.*
+# @sacloud-require-archive distro-centos distro-ver-6.*
+#
+# @sacloud-desc-begin
+#    Initial setup script for CentOS7.x or CentOS6.x
+#    CentOS 7.x or 6.xの初期設定をします
+# @sacloud-desc-end
+#
+# @sacloud-text required shellarg maxlen=60 user_name "新規追加するユーザ名"
+# @sacloud-password required shellarg maxlen=60 user_pass "新規追加するユーザのパスワード"
+# @sacloud-textarea required shellarg maxlen=512 public_key "利用する公開鍵"
+# @sacloud-radios-begin required default=7 centos_version "CentOSのバージョン"
+#   7 "CentOS7.x系"
+#   6 "CentOS6.x系"
+# @sacloud-radios-end
+
+USER=@@@user_name@@@
+PW=@@@user_pass@@@
+PUBKEY=@@@public_key@@@
+CENTOS_VERSION=@@@centos_version@@@
+
+# disable SELinux temporarily
+setenforce 0
+
+
+# package update
+yum -y update
+
+
+# create user
+useradd $USER
+echo $PW | passwd --stdin $USER
+gpasswd -a $USER wheel
+
+
+# allow only members of the wheel group to use 'su'
+cp /etc/pam.d/su /etc/pam.d/su.bak
+## uncomment 'auth required pam_wheel.so use_uid'
+tac /etc/pam.d/su > /etc/pam.d/su.tmp
+cat << EOS >> /etc/pam.d/su.tmp 2>&1
+auth required pam_wheel.so use_uid
+EOS
+tac /etc/pam.d/su.tmp > /etc/pam.d/su
+rm -rf /etc/pam.d/su.tmp
+
+## restrict the use of 'su' command
+cp /etc/login.defs /etc/login.defs.bak
+cat << EOS >> /etc/login.defs
+SU_WHEEL_ONLY yes
+EOS
+
+## 'sudo' command without password
+cp /etc/sudoers /etc/sudoers.bak
+cat << EOS >> /etc/sudoers 2>&1
+%wheel ALL=(ALL) NOPASSWD: ALL
+EOS
+
+
+# disallow SSH login and add public_key
+cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
+cat << EOS >> /etc/ssh/sshd_config 2>&1
+PermitRootLogin no
+PubkeyAuthentication yes
+PasswordAuthentication no
+AuthorizedKeysFile .ssh/authorized_keys
+EOS
+
+
+mkdir /home/$USER/.ssh/
+chmod go-w /home/$USER/.ssh/
+touch /home/$USER/.ssh/authorized_keys
+cat << EOS >> /home/$USER/.ssh/authorized_keys 2>&1
+$PUBKEY
+EOS
+chmod 600 /home/$USER/.ssh/authorized_keys
+chown -R $USER:$USER /home/$USER/.ssh/
+
+
+# sshd service restart
+if [ $CENTOS_VERSION = "7" ]; then
+  systemctl restart sshd
+elif [ $CENTOS_VERSION = "6" ]; then
+  /etc/rc.d/init.d/sshd restart
+fi
+
+exit 0


### PR DESCRIPTION
CentOS 6.x/7.xの初期設定をするスクリプトを追加いたしました 🙏 

行う設定は、以下のとおりです。
* パッケージの最新化
* 新規ユーザの作成
* suコマンドの制限
  * suコマンドの実行可能ユーザ・グループを限定する
  * パスワード入力なしでsudoコマンドを利用可能にする
* ssh接続の制限
  * rootユーザのsshログインを禁止する
  * 公開鍵認証のみ接続を許可する（パスワード認証を禁止）