### PR TITLE
minio

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 | 開発言語・フレームワーク | [Node-RED](./publicscript/node-red.sh) | ブラウザの操作だけでハードウェア・デバイスを制御できるプログラミング・ツール「Node-RED」をインストールします。<br />※CentOS7系のみで動作します |
 | 開発言語・フレームワーク | [Ruby on Rails](./publicscript/ruby_on_rails.sh) | スクリプト言語RubyのフレームワークであるRuby on Railsをインストールします。 |
 | プロジェクト管理 | [Redmine](./publicscript/redmine.sh) | プロジェクト管理ソフトウェアのRedmineをインストールし、起動時に動作する状態に設定します。 |
+| オブジェクトストレージ | [Minio](./publicscript/minio.sh) |  [minio](https://minio.io/) という管理用UIやAPIを備えるオブジェクトストレージサーバをインストールします。 <br />※Ubuntu 16.04のみで動作します |
 
 
 ## <a name="sacloud">さくらのクラウド開発ツール・設定支援</a>

--- a/publicscript/minio.sh
+++ b/publicscript/minio.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+set -eux
+
+# @sacloud-once
+# @sacloud-desc-begin
+# Nginx, minio をインストールするスクリプトです。
+# fluent-plugin-dstatを有効にすると、dstatをインストールし、
+# dstatの実行結果が保存され、可視化することができます。
+# Debian系でsystemdにのみに対応しているスクリプトです。
+# サーバ作成後、http://<サーバのIPアドレス>/ にアクセスください。
+# 管理画面を有効にした場合、指定したAccess KeyとSecret Keyで管理画面で操作できます。
+# @sacloud-desc-end
+# @sacloud-text required minlen=5 maxlen=20 ex="accessKey" shellarg accesskey 'API Access Key'
+# @sacloud-password required minlen=8 maxlen=100 ex="secretKey" shellarg secretkey 'API Secret Key'
+# @sacloud-text required default="us-east-1" shellarg region 'リージョン名'
+# @sacloud-checkbox default="on" shellarg enablecpanel '管理画面を有効にする'
+
+#===== Sacloud Vars =====#
+MINIO_ACCESS_KEY=@@@accesskey@@@
+MINIO_SECRET_KEY=@@@secretkey@@@
+MINIO_REGION=@@@region@@@
+MINIO_CPANEL_ENABLED=@@@enablecpanel@@@
+if [ -z $MINIO_CPANEL_ENABLED ]; then
+  MINIO_BROWSER="off"
+else
+  MINIO_BROWSER="on"
+fi
+#===== Sacloud Vars =====#
+
+#===== Consts =====#
+export DEBIAN_FRONTEND=noninteractive
+MINIO_RELEASE_URL=https://dl.minio.io/server/minio/release/linux-amd64/minio
+MINIO_BIN=/usr/local/bin/minio
+MINIO_PORT=9000
+MINIO_DATA_DIR=/var/minio
+#===== Consts =====#
+
+#===== Common =====#
+echo "[*] Set up ufw ..."
+ufw allow 22 || exit 1
+ufw allow 80 || exit 1
+ufw allow 443 || exit 1
+ufw enable || exit 1
+
+echo "[*] Updating packages ..."
+apt-get update
+apt-get upgrade -y
+
+echo "[*] Installing required packages ..."
+apt-get install -y nginx wget
+#===== Common =====#
+
+
+#===== Nginx =====#
+echo "[*] Stopping Nginx ..."
+systemctl stop nginx
+
+echo "[*] Configuring /etc/nginx/conf.d/minio_upstream.conf ..."
+cat << __EOT__ > /etc/nginx/conf.d/minio_upstream.conf
+upstream minio {
+  server 127.0.0.1:${MINIO_PORT};
+}
+__EOT__
+
+echo "[*] Configuring /etc/nginx/sites-available/default ..."
+cat << __EOT__ > /etc/nginx/sites-available/default
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	root /var/www/html;
+
+	server_name _;
+
+	location / {
+		include proxy_params;
+		proxy_pass http://minio;
+	}
+}
+__EOT__
+
+echo "[*] Enable & Start Nginx ..."
+systemctl enable nginx
+systemctl start nginx
+echo "[+] success"
+#===== Nginx =====#
+
+
+#===== minio =====#
+echo "[*] Creating minio user and group ..."
+groupadd minio
+useradd -g minio -d ${MINIO_DATA_DIR} -c "minio" minio
+
+echo "[*] Creating minio directory ..."
+mkdir -p ${MINIO_DATA_DIR}
+chown minio ${MINIO_DATA_DIR}
+
+echo "[*] Installing minio ..."
+wget -O ${MINIO_BIN} ${MINIO_RELEASE_URL}
+chmod +x ${MINIO_BIN}
+
+
+echo "[*] Configuring /etc/default/minio ..."
+cat << __EOT__ > /etc/default/minio
+# Remote node configuration.
+MINIO_VOLUMES=${MINIO_DATA_DIR}
+# Use if you want to run Minio on a custom port.
+MINIO_OPTS="--address 127.0.0.1:${MINIO_PORT}"
+# Enable browser Access
+MINIO_BROWSER=${MINIO_BROWSER}
+
+# Access Key of the server.
+MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+# Secret key of the server.
+MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+__EOT__
+
+
+echo "[*] Configuring /etc/systemd/system/minio.service ..."
+cat << __EOT__ > /etc/systemd/system/minio.service
+[Unit]
+Description=Minio
+Documentation=https://docs.minio.io
+Wants=network-online.target
+After=network-online.target
+AssertFileIsExecutable=${MINIO_BIN}
+
+[Service]
+WorkingDirectory=${MINIO_DATA_DIR}
+User=minio
+Group=minio
+PermissionsStartOnly=true
+EnvironmentFile=-/etc/default/minio
+ExecStart=${MINIO_BIN} server \$MINIO_OPTS \$MINIO_VOLUMES
+StandardOutput=journal
+StandardError=inherit
+
+# Specifies the maximum file descriptor number that can be opened by this process
+LimitNOFILE=65536
+
+# Disable timeout logic and wait until process is stopped
+TimeoutStopSec=0
+
+# SIGTERM signal is used to stop Minio
+KillSignal=SIGTERM
+
+SendSIGKILL=no
+
+SuccessExitStatus=0
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+__EOT__
+
+
+echo "[*] Enable & Start minio ..."
+systemctl enable minio
+systemctl start minio
+echo "[+] success"
+#===== minio =====#
+
+
+echo "[+] Install Finished."


### PR DESCRIPTION
Goで記述されたオブジェクトストレージサーバのminioをインストールします。

スタートアップスクリプトの処理

1. パッケージのアップデート
2. Nginxのインストール
3. minioのインストール

## 対応OS

systemdが利用さているDebian系OS。
Ubuntu16.04で動作確認済み。

## 外部ドキュメント

- [https://github.com/minio/minio](https://github.com/minio/minio)
- [Documents of minio](https://docs.minio.io/)

## 未対応

- SSL対応
- サブドメインでのバケットアクセス
