### PR TITLE
minioスクリプトで、Ubuntu 16.04の制限を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 | 開発言語・フレームワーク | [Node-RED](./publicscript/node-red.sh) | ブラウザの操作だけでハードウェア・デバイスを制御できるプログラミング・ツール「Node-RED」をインストールします。<br />※CentOS7系のみで動作します |
 | 開発言語・フレームワーク | [Ruby on Rails](./publicscript/ruby_on_rails.sh) | スクリプト言語RubyのフレームワークであるRuby on Railsをインストールします。 |
 | プロジェクト管理 | [Redmine](./publicscript/redmine.sh) | プロジェクト管理ソフトウェアのRedmineをインストールし、起動時に動作する状態に設定します。 |
-| オブジェクトストレージ | [Minio](./publicscript/minio.sh) |  [minio](https://minio.io/) という管理用UIやAPIを備えるオブジェクトストレージサーバをインストールします。 <br />※Ubuntu 16.04のみで動作します |
+| オブジェクトストレージ | [Minio](./publicscript/minio.sh) |  [minio](https://minio.io/) という管理用UIやAPIを備えるオブジェクトストレージサーバをインストールします。 例えば、fluent-plugin-dstat のデータ保存先としても活用可能であり、kibanaと連携してdstatの可視化も可能です<br />※Ubuntu 16.04のみで動作します |
 
 
 ## <a name="sacloud">さくらのクラウド開発ツール・設定支援</a>

--- a/publicscript/minio.sh
+++ b/publicscript/minio.sh
@@ -8,8 +8,6 @@ set -eux
 # (このスクリプトは Ubuntu Server 16.04* でのみ動作します)
 # 管理画面を有効にした場合、指定したAccess KeyとSecret Key（さくらのクラウドAPIとは異なります）で管理画面を操作できます。
 # サーバ作成後、http://<サーバのIPアドレス>/ にアクセスください。
-# 別途、fluent-plugin-dstatを有効にすると、dstatをインストールし、
-# dstatの実行結果が保存され、可視化することができます。
 # Debian系でsystemdにのみに対応しているスクリプトです。
 # @sacloud-desc-end
 # @sacloud-require-archive distro-ubuntu distro-ver-16.04*

--- a/publicscript/minio.sh
+++ b/publicscript/minio.sh
@@ -14,8 +14,8 @@ set -eux
 # @sacloud-desc-end
 # @sacloud-require-archive distro-ubuntu distro-ver-16.04*
 # @sacloud-checkbox default="on" shellarg enablecpanel '管理画面を有効にする'
-# @sacloud-text required minlen=5 maxlen=20 ex="accessKey" shellarg accesskey '管理画面用 Access Key'
-# @sacloud-password required minlen=8 maxlen=100 ex="secretKey" shellarg secretkey '管理画面用 Secret Key'
+# @sacloud-text required minlen=5 maxlen=20 ex="accessKey" shellarg accesskey '管理画面用 / API Access Key'
+# @sacloud-password required minlen=8 maxlen=100 ex="secretKey" shellarg secretkey '管理画面用 / API Secret Key'
 # @sacloud-text required default="us-east-1" shellarg region 'リージョン名'
 
 #===== Sacloud Vars =====#

--- a/publicscript/minio.sh
+++ b/publicscript/minio.sh
@@ -6,17 +6,17 @@ set -eux
 # @sacloud-desc-begin
 # Nginx, minio をインストールするスクリプトです。
 # (このスクリプトは Ubuntu Server 16.04* でのみ動作します)
-# fluent-plugin-dstatを有効にすると、dstatをインストールし、
+# 管理画面を有効にした場合、指定したAccess KeyとSecret Key（さくらのクラウドAPIとは異なります）で管理画面を操作できます。
+# サーバ作成後、http://<サーバのIPアドレス>/ にアクセスください。
+# 別途、fluent-plugin-dstatを有効にすると、dstatをインストールし、
 # dstatの実行結果が保存され、可視化することができます。
 # Debian系でsystemdにのみに対応しているスクリプトです。
-# サーバ作成後、http://<サーバのIPアドレス>/ にアクセスください。
-# 管理画面を有効にした場合、指定したAccess KeyとSecret Keyで管理画面で操作できます。
 # @sacloud-desc-end
 # @sacloud-require-archive distro-ubuntu distro-ver-16.04*
-# @sacloud-text required minlen=5 maxlen=20 ex="accessKey" shellarg accesskey 'API Access Key'
-# @sacloud-password required minlen=8 maxlen=100 ex="secretKey" shellarg secretkey 'API Secret Key'
-# @sacloud-text required default="us-east-1" shellarg region 'リージョン名'
 # @sacloud-checkbox default="on" shellarg enablecpanel '管理画面を有効にする'
+# @sacloud-text required minlen=5 maxlen=20 ex="accessKey" shellarg accesskey '管理画面用 Access Key'
+# @sacloud-password required minlen=8 maxlen=100 ex="secretKey" shellarg secretkey '管理画面用 Secret Key'
+# @sacloud-text required default="us-east-1" shellarg region 'リージョン名'
 
 #===== Sacloud Vars =====#
 MINIO_ACCESS_KEY=@@@accesskey@@@

--- a/publicscript/minio.sh
+++ b/publicscript/minio.sh
@@ -5,12 +5,14 @@ set -eux
 # @sacloud-once
 # @sacloud-desc-begin
 # Nginx, minio をインストールするスクリプトです。
+# (このスクリプトは Ubuntu Server 16.04* でのみ動作します)
 # fluent-plugin-dstatを有効にすると、dstatをインストールし、
 # dstatの実行結果が保存され、可視化することができます。
 # Debian系でsystemdにのみに対応しているスクリプトです。
 # サーバ作成後、http://<サーバのIPアドレス>/ にアクセスください。
 # 管理画面を有効にした場合、指定したAccess KeyとSecret Keyで管理画面で操作できます。
 # @sacloud-desc-end
+# @sacloud-require-archive distro-ubuntu distro-ver-16.04*
 # @sacloud-text required minlen=5 maxlen=20 ex="accessKey" shellarg accesskey 'API Access Key'
 # @sacloud-password required minlen=8 maxlen=100 ex="secretKey" shellarg secretkey 'API Secret Key'
 # @sacloud-text required default="us-east-1" shellarg region 'リージョン名'


### PR DESCRIPTION
`ufw` コマンドを使うことから、現時点で対応しているパブリックアーカイブは `Ubuntu 16.04` のみです。
そのため、説明文とスタートアップスクリプトで OS 制限を追加しました。