### PR TITLE
GitLab CE

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 | 開発言語・フレームワーク | [LAMP](./publicscript/lamp.sh) | yumによりApache、MySQL、PHPをインストールし、LAMP構成を作成します。 | 
 | 開発言語・フレームワーク | [Node-RED](./publicscript/node-red.sh) | ブラウザの操作だけでハードウェア・デバイスを制御できるプログラミング・ツール「Node-RED」をインストールします。<br />※CentOS7系のみで動作します |
 | 開発言語・フレームワーク | [Ruby on Rails](./publicscript/ruby_on_rails.sh) | スクリプト言語RubyのフレームワークであるRuby on Railsをインストールします。 |
+| プロジェクト管理 | [GitLab CE](./publicscript/gitlab.sh) | GitHubライクなGitリポジトリ管理機能を持つモダン開発者向けプラットフォーム「[GitLab](https://about.gitlab.com)」をインストールします。 |
 | プロジェクト管理 | [Redmine](./publicscript/redmine.sh) | プロジェクト管理ソフトウェアのRedmineをインストールし、起動時に動作する状態に設定します。 |
 | オブジェクトストレージ | [Minio](./publicscript/minio.sh) |  [minio](https://minio.io/) という管理用UIやAPIを備えるオブジェクトストレージサーバをインストールします。 例えば、fluent-plugin-dstat のデータ保存先としても活用可能であり、kibanaと連携してdstatの可視化も可能です<br />※Ubuntu 16.04のみで動作します |
 

--- a/publicscript/gitlab.sh
+++ b/publicscript/gitlab.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# @sacloud-once
+# @sacloud-desc-begin
+#   GitLabをインストールします。
+#   サーバ作成後、WebブラウザでサーバのIPアドレスにアクセスしてください。
+#   http://サーバのIPアドレス/
+#   ※ セットアップには5分程度時間がかかります。
+#   （このスクリプトは、CentOS7.Xでのみ動作します）
+# @sacloud-desc-end
+# @sacloud-password required shellarg maxlen=100 minlen=8 ex="put_password_here" GITLAB_INITIAL_PASSWORD "管理者(rootユーザ)の初期パスワード(8文字以上)"
+
+set +e
+
+export GITLAB_ROOT_PASSWORD=@@@GITLAB_INITIAL_PASSWORD@@@
+
+#*******************************************************************************
+# ref: https://about.gitlab.com/installation/#centos-7
+#*******************************************************************************
+
+# 1. Install and configure the necessary dependencies
+yum install curl policycoreutils openssh-server openssh-clients -y
+yum install postfix -y
+systemctl enable postfix
+systemctl start postfix
+firewall-cmd --permanent --add-service=http
+firewall-cmd --reload
+
+# 2. Add the GitLab package server and install the package
+curl -sS https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.rpm.sh | bash
+yum install gitlab-ce -y
+
+# 3. Configure and start GitLab
+gitlab-ctl reconfigure
+
+exit 0


### PR DESCRIPTION
## 概要

モダン開発者向けプラットフォーム「[GitLab](https://about.gitlab.com)」をインストールします。

## 対応OS

CentOS7.xでのみ動作します。

## 処理内容

#### GitLab CEのインストール

公式ドキュメントのインストールガイド(CentOS7用)に従いGitLab CEをインストールします。

> インストールについてのドキュメント:   
https://about.gitlab.com/installation/#centos-7

#### GitLab管理者(rootユーザ)のパスワード設定

GitLabにログインする際に利用するrootユーザのパスワードを設定します。

> パスワード設定についてのドキュメント:  
https://docs.gitlab.com/ce/install/installation.html#initialize-database-and-activate-advanced-features
