### PR TITLE
owncloud 10 対応 & CentOS7 対応

### DIFF
--- a/publicscript/owncloud/owncloud.sh
+++ b/publicscript/owncloud/owncloud.sh
@@ -1,44 +1,73 @@
 #!/bin/bash
-# @sacloud-once
-# @sacloud-desc OwnCloudをセットアップします。
-# @sacloud-desc （このスクリプトは、CentOS6.XもしくはScientific Linux6.Xでのみ動作します）
-# @sacloud-require-archive distro-centos distro-ver-6.*
-# @sacloud-require-archive distro-sl distro-ver-6.*
 
-#---------START OF iptables---------#
-cat <<'EOT' > /etc/sysconfig/iptables
-*filter
-:INPUT DROP [0:0]
-:FORWARD DROP [0:0]
-:OUTPUT ACCEPT [0:0]
-:fail2ban-SSH - [0:0]
--A INPUT -p tcp -m multiport --dports 22 -j fail2ban-SSH 
--A INPUT -p TCP -m state --state NEW ! --syn -j DROP
--A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT 
--A INPUT -p icmp -j ACCEPT 
--A INPUT -i lo -j ACCEPT 
--A INPUT -p tcp -m tcp --dport 80 -j ACCEPT
--A INPUT -p udp --sport 123 --dport 123 -j ACCEPT
--A INPUT -p udp --sport 53 -j ACCEPT
--A INPUT -p tcp -m tcp --dport 22 -j ACCEPT 
--A fail2ban-SSH -j RETURN
-COMMIT
-EOT
-service iptables restart
-#---------END OF iptables---------#
-#---------START OF owncloud---------#
-wget -O "/etc/yum.repos.d/isv:ownCloud:community.repo" 'http://download.opensuse.org/repositories/isv:ownCloud:community/CentOS_CentOS-6/isv:ownCloud:community.repo'
-yum install -y --enablerepo=remi php
-yum install -y --enablerepo=remi php-gd php-pdo php-mbstring php-process php-xml php-ldap
-yum install -y owncloud
-cat <<'EOT'>/var/www/html/owncloud/config/config.php
+# @sacloud-once
+#
+# @sacloud-desc-begin OwnCloudをセットアップします。
+# サーバ作成後、WebブラウザでサーバのIPアドレスにアクセスしてください。
+# http://サーバのIPアドレス/owncloud/
+#（このスクリプトは、CentOS6.X,7.Xで動作します）
+# @sacloud-desc-end
+# @sacloud-require-archive distro-centos distro-ver-7.*
+# @sacloud-require-archive distro-centos distro-ver-6.*
+
+set -eux
+DIST_VER=`cat /etc/redhat-release | perl -pe 's/.*release ([0-9.]+) .*/$1/' | cut -d "." -f 1`
+
+
+if [ $DIST_VER = "7" ];then
+  yum install -y wget
+  wget http://download.owncloud.org/download/repositories/production/CentOS_7/ce:stable.repo -O /etc/yum.repos.d/ce:stable.repo
+  yum install -y --enablerepo=remi,remi-php71 php
+  yum install -y --enablerepo=remi,remi-php71 php-gd php-pdo php-mbstring php-process php-xml php-ldap php-zip
+  yum install -y owncloud-files
+  
+  cat <<'EOT'>/var/www/html/owncloud/config/config.php
 <?php
 $CONFIG = array (
   'default_language' => 'ja_JP'
 );
 EOT
-chown apache:apache /var/www/html/owncloud/config/config.php
-service httpd start
-chkconfig httpd on
-
-#---------END OF owncloud---------#
+  chown apache:apache /var/www/html/owncloud/config/config.php
+  
+  firewall-cmd --add-service=http --zone=public --permanent
+  firewall-cmd --reload
+  
+  systemctl enable httpd
+  systemctl start httpd
+elif [ $DIST_VER = "6" ];then
+  cat <<'EOT' > /etc/sysconfig/iptables
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+:fail2ban-SSH - [0:0]
+-A INPUT -p tcp -m multiport --dports 22 -j fail2ban-SSH
+-A INPUT -p TCP -m state --state NEW ! --syn -j DROP
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+-A INPUT -i lo -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 80 -j ACCEPT
+-A INPUT -p udp --sport 123 --dport 123 -j ACCEPT
+-A INPUT -p udp --sport 53 -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+-A fail2ban-SSH -j RETURN
+COMMIT
+EOT
+  service iptables restart
+  #---------END OF iptables---------#
+  #---------START OF owncloud---------#
+  wget http://download.owncloud.org/download/repositories/production/CentOS_6/ce:stable.repo -O /etc/yum.repos.d/ce:stable.repo
+  yum install -y  libwebp --enablerepo=epel
+  yum install -y --enablerepo=remi,remi-php56 php
+  yum install -y --enablerepo=remi,remi-php56 php-gd php-pdo php-mbstring php-process php-xml php-ldap
+  yum install -y owncloud-files
+  cat <<'EOT'>/var/www/html/owncloud/config/config.php
+<?php
+$CONFIG = array (
+  'default_language' => 'ja_JP'
+);
+EOT
+  chown apache:apache /var/www/html/owncloud/config/config.php
+  service httpd start
+  chkconfig httpd on
+fi


### PR DESCRIPTION
2017/09/20現在公開されているスタートアップスクリプトを利用してowncloudサーバの構築を試みたところ、スクリプトの実行が失敗しておりました。
原因を調査してみたところ、スクリプトが参照しているowncloudのリポジトリが利用不能となっているようでした。
そこで、公式サイトを見ながら最新版のowncloudをインストールできるようにしてみました。
PHPは5.6にしないと怒られたので5.6で入れており、それに付随して必要なソフトウェアもインストールし、説明部分も補足しました。
折角なのでCentOS7版も作り、まとめました。