### PR TITLE
Terraform for さくらのクラウド 配布サイトのURL変更対応

### DIFF
--- a/publicscript/terraform_for_sacloud/terraform_for_sacloud.sh
+++ b/publicscript/terraform_for_sacloud/terraform_for_sacloud.sh
@@ -48,7 +48,7 @@ if [ ${actual_checksum} != ${expected_checksum} ]; then
 fi
 
 # Terraform for さくらのクラウド
-curl -sL https://terraform.b.sakurastorage.jp/downloads/terraform-provider-sakuracloud_linux-amd64.zip > terraform-provider-sakuracloud_linux-amd64.zip
+curl -sL http://releases.usacloud.jp/terraform/terraform-provider-sakuracloud_linux-amd64.zip > terraform-provider-sakuracloud_linux-amd64.zip
 
 unzip $terraform_file
 unzip terraform-provider-sakuracloud_linux-amd64.zip


### PR DESCRIPTION
Terraform for さくらのクラウドの配布サイトのURL変更への対応を行いました。

- 旧: `https://terraform.b.sakurastorage.jp/downloads/`
- 新: `http://releases.usacloud.jp/terraform/`
