### PR TITLE
Usacloud 配布サイトURLの変更対応

### DIFF
--- a/publicscript/usacloud/usacloud.sh
+++ b/publicscript/usacloud/usacloud.sh
@@ -22,7 +22,7 @@ yum install -y yum-utils bash-completion
 yum-config-manager --enable epel
 yum install -y jq
 # usacloud install
-curl -fsSL https://usacloud.b.sakurastorage.jp/repos/setup-yum.sh | sh
+curl -fsSL http://releases.usacloud.jp/usacloud/repos/setup-yum.sh | sh
 # get zone name
 ZONE=@@@ZONE@@@
 if [ "${ZONE}" = "default" ]


### PR DESCRIPTION
Usacloudの配布サイトのURL変更への対応を行いました。

- 旧: `https://usacloud.b.sakurastorage.jp/repos/setup-yum.sh`
- 新: `http://releases.usacloud.jp/usacloud/repos/setup-yum.sh`
