### PR TITLE
RancherOSにSSH公開鍵を設定するスクリプト

### DIFF
--- a/publicscript/rancheros-ssh-config/cloud-config.yml
+++ b/publicscript/rancheros-ssh-config/cloud-config.yml
@@ -1,0 +1,11 @@
+#cloud-config
+#
+# @sacloud-require-archive distro-rancheros
+# @sacloud-desc-begin
+# RanchrOSのSSH公開鍵を設定します。
+# @sacloud-desc-end
+#
+# @sacloud-text required ex="ssh-rsa xxxxXXXXxxxxXXXX" key "ssh 公開鍵"
+
+ssh_authorized_keys:
+  - @@@key@@@


### PR DESCRIPTION
RancherOSのSSH公開鍵を設定するためのスタートアップスクリプトです。

SSH公開鍵はテキストボックスから入力するようにしています。