### PR TITLE
Drupal for CentOS7 - Remiリポジトリの利用を明示

### DIFF
--- a/publicscript/drupal_for_centos7/drupal_for_centos7.sh
+++ b/publicscript/drupal_for_centos7/drupal_for_centos7.sh
@@ -29,6 +29,7 @@ DRUPAL_VERSION=@@@drupal_version@@@
 # 必要なミドルウェアを全てインストール
 yum makecache fast || exit 1
 # Drupal 7, 8 共通のパッケージをインストール
+yum -y localinstall http://rpms.famillecollet.com/enterprise/remi-release-7.rpm
 yum -y install mariadb mariadb-server httpd || exit 1
 if [ $DRUPAL_VERSION -eq 7 ]; then
   yum -y install php php-mysql php-gd php-dom php-mbstring || exit 1


### PR DESCRIPTION
Drupalセットアップ時に必要となるRemiリポジトリを、スクリプト内でセットアップするよう明示しまいた。
