### PR TITLE
#72 Shirasagiインストールスクリプトの更新に伴い、ポート番号変更に対応

### DIFF
--- a/publicscript/shirasagi/shirasagi.sh
+++ b/publicscript/shirasagi/shirasagi.sh
@@ -10,7 +10,7 @@
 #   example.jpの部分は、ご利用のドメインに応じて適時変更してください。
 #
 #   サーバ作成後、Webブラウザでシラサギの管理画面にアクセスしてください。
-#   http://IPアドレス:3000/.mypage
+#   http://IPアドレス/.mypage
 #   初期ID/パスワードは下記URLを参照してください。
 #   http://www.ss-proj.org/download/demo.html
 #
@@ -39,11 +39,5 @@ fi
 curl https://raw.githubusercontent.com/shirasagi/shirasagi/master/bin/install.sh | bash -s ${SS__HOST}
 #---------END OF SHIRASAGI---------#
 
-#---------START OF firewalld---------#
-# シラサギの管理画面は3000番ポートを使用するため、
-# サーバに対して3000番ポートでアクセスできるようにします。
-firewall-cmd --permanent --add-port=3000/tcp
-firewall-cmd --reload
-#---------END OF firewalld---------#
 
 exit 0


### PR DESCRIPTION
インストール用スクリプトが、デフォルトでポート80を公開するようになった対応
- デフォルトのポートが 3000 から 80 に変更
- firewall-cmd もスクリプト側で対処しているので、スタートアップスクリプト側からは削除