### PR TITLE
Feature/mattermost letsencrypt acme v2

### DIFF
--- a/publicscript/crowi/crowi.sh
+++ b/publicscript/crowi/crowi.sh
@@ -293,7 +293,7 @@ then
 	git clone https://github.com/certbot/certbot ${CPATH}
 	WROOT=/opt/crowi/public
 	DOMAIN=${DOMAIN}
-	${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m root@${DOMAIN} --agree-tos
+	${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m root@${DOMAIN} --agree-tos --server https://acme-v02.api.letsencrypt.org/directory
 
 	CERT=/etc/letsencrypt/live/${DOMAIN}/fullchain.pem
 	CKEY=/etc/letsencrypt/live/${DOMAIN}/privkey.pem

--- a/publicscript/letsencrypt/letsencrypt.sh
+++ b/publicscript/letsencrypt/letsencrypt.sh
@@ -214,7 +214,7 @@ systemctl enable nginx
 # Configure Let's Encrypt
 WROOT=/usr/share/nginx/html
 systemctl start nginx
-CA="${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m ${MADDR} --agree-tos"
+CA="${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m ${MADDR} --agree-tos --server https://acme-v02.api.letsencrypt.org/directory"
 
 for x in 1 2 3 4
 do

--- a/publicscript/mastodon/mastodon.sh
+++ b/publicscript/mastodon/mastodon.sh
@@ -40,8 +40,6 @@ source /etc/sysconfig/network-scripts/ifcfg-eth0
 DOMAIN="@@@ZONE@@@"
 MADDR=mastodon@${DOMAIN}
 
-yum install -y yum-utils
-yum-config-manager --enable epel
 yum install -y http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
 curl -sL https://rpm.nodesource.com/setup_6.x | bash -
 
@@ -314,7 +312,7 @@ firewall-cmd --reload
 CPATH=/usr/local/certbot
 git clone https://github.com/certbot/certbot ${CPATH}
 WROOT=/usr/share/nginx/html
-${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m ${MADDR} --agree-tos
+${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m ${MADDR} --agree-tos --server https://acme-v02.api.letsencrypt.org/directory
 
 if [ ! -f ${CERT} ]
 then

--- a/publicscript/mattermost/mattermost.sh
+++ b/publicscript/mattermost/mattermost.sh
@@ -188,7 +188,7 @@ mysql -e "SET GLOBAL validate_password_policy=LOW;" ;
 mysql -e "SET GLOBAL validate_password_length=7;"
 
 # mattermost
-VERSION=4.3.1
+VERSION=4.9.1
 curl -O https://releases.mattermost.com/${VERSION}/mattermost-team-${VERSION}-linux-amd64.tar.gz
 tar xpf mattermost-team-${VERSION}-linux-amd64.tar.gz
 mv mattermost /opt/
@@ -327,7 +327,7 @@ firewall-cmd --reload
 CPATH=/usr/local/certbot
 git clone https://github.com/certbot/certbot ${CPATH}
 WROOT=/usr/share/nginx/html
-CA="${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m root@${DOMAIN} --agree-tos"
+CA="${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m root@${DOMAIN} --agree-tos --server https://acme-v02.api.letsencrypt.org/directory"
 sleep 180
 
 for x in 1 2 3 4


### PR DESCRIPTION
certbot で ACME v2 エンドポイントを使用するように変更
mattermost のバージョンを 4.3.1 から 4.9.1 に変更