### PR TITLE
KUSANAGI v8.1.0以降のパラメータ指定対応

### DIFF
--- a/publicscript/wordpress_for_kusanagi8/wordpress_for_kusanagi8.sh
+++ b/publicscript/wordpress_for_kusanagi8/wordpress_for_kusanagi8.sh
@@ -44,7 +44,8 @@ echo "## Kusanagi init";
 kusanagi init --tz Asia/Tokyo --lang ja --keyboard ja \
   --passwd @@@KUSANAGI_PASSWD@@@ --no-phrase \
   --dbrootpass @@@DBROOT_PASSWD@@@ \
-  --nginx --hhvm || exit 1
+  --nginx --hhvm --ruby24 \
+  --dbsystem mariadb || exit 1
 
 echo "## Kusanagi provision";
 kusanagi provision \


### PR DESCRIPTION
kusanagi initコマンド実行時において、8.1.0から--ruby24、8.2.0から--dbsystem [mariadb|psql]のパラメータ指定が増えたので追加いたしました。