### PR TITLE
ex で文字数の範囲を指定している箇所を削除

### DIFF
--- a/publicscript/wordpress_for_kusanagi8/wordpress_for_kusanagi8.sh
+++ b/publicscript/wordpress_for_kusanagi8/wordpress_for_kusanagi8.sh
@@ -21,11 +21,11 @@
 # @sacloud-desc-end
 #
 # 管理ユーザーの入力フォームの設定
-# @sacloud-password required shellarg maxlen=60 minlen=6 KUSANAGI_PASSWD  "ユーザー kusanagi のパスワード" ex="6?60文字"
-# @sacloud-password required shellarg maxlen=60 minlen=6 DBROOT_PASSWD    "MariaDB root ユーザーのパスワード" ex="6?60文字"
-# @sacloud-text     required shellarg maxlen=60 WP_ADMIN_USER    "WordPress 管理者ユーザ名 (半角英数字、下線、ハイフン、ピリオド、アットマーク (@) のみが使用可能)" ex="1?60文字"
-# @sacloud-password required shellarg maxlen=60 minlen=6 WP_ADMIN_PASSWD  "WordPress 管理者パスワード" ex="6?60文字"
-# @sacloud-text     required shellarg maxlen=256 WP_TITLE        "WordPress サイトのタイトル (256文字以下)"
+# @sacloud-password required shellarg maxlen=60 minlen=6 KUSANAGI_PASSWD  "ユーザー kusanagi のパスワード"
+# @sacloud-password required shellarg maxlen=60 minlen=6 DBROOT_PASSWD    "MariaDB root ユーザーのパスワード"
+# @sacloud-text     required shellarg maxlen=60 WP_ADMIN_USER    "WordPress 管理者ユーザ名 (半角英数字、下線、ハイフン、ピリオド、アットマーク (@) のみが使用可能)"
+# @sacloud-password required shellarg maxlen=60 minlen=6 WP_ADMIN_PASSWD  "WordPress 管理者パスワード"
+# @sacloud-text     required shellarg maxlen=256 WP_TITLE        "WordPress サイトのタイトル"
 # @sacloud-text     required  maxlen=128 WP_ADMIN_MAIL   "WordPress 管理者メールアドレス (インストール完了時にメールが送信されます)" ex="user@example.com"
 
 echo "## set default variables";


### PR DESCRIPTION
maxlen、minlen が存在する場合、 ex での指定がなくてもデフォルトの挙動として文字数の範囲が表示されるため