### PR TITLE
スタートアップスクリプトが完了しない問題を対応しました。

### DIFF
--- a/publicscript/gitlab/gitlab.sh
+++ b/publicscript/gitlab/gitlab.sh
@@ -32,7 +32,7 @@ curl -sS https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/scrip
 yum install gitlab-ce -y
 
 # 3. Configure and start GitLab
-gitlab-ctl reconfigure
+gitlab-ctl reconfigure &
 
 # 4. Configure and restart sshd
 sed -i "/^# problems./a UsePAM yes" /etc/ssh/sshd_config


### PR DESCRIPTION
runsvdir-start.service の起動から処理が進まない現象を確認したため、スクリプトを修正しました。
恐らく runsvdir-start.service ファイルで After=multi-user.target が指定されるようになった為だと思われます。