### PR TITLE
node のバージョンを 6 から 8 に変更しました。

### DIFF
--- a/publicscript/mastodon/mastodon.sh
+++ b/publicscript/mastodon/mastodon.sh
@@ -41,7 +41,7 @@ DOMAIN="@@@ZONE@@@"
 MADDR=mastodon@${DOMAIN}
 
 yum install -y http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
-curl -sL https://rpm.nodesource.com/setup_6.x | bash -
+curl -sL https://rpm.nodesource.com/setup_8.x | bash -
 
 yum update -y
 yum install -y ImageMagick ffmpeg redis rubygem-redis postgresql96-{server,contrib,devel} authd nodejs {openssl,readline,zlib,libxml2,libxslt,protobuf,ffmpeg,libidn,libicu}-devel protobuf-compiler nginx jq bind-utils


### PR DESCRIPTION
mastodon の 2.5.0 で必要な node のバージョンに変更があった為、対応しました。