### PR TITLE
Rancher2セットアップ: 'docker exec'エラー回避のためdockerをダウングレード

### DIFF
--- a/publicscript/rancher2_setup/rancher2_setup.sh
+++ b/publicscript/rancher2_setup/rancher2_setup.sh
@@ -58,6 +58,12 @@ DEFAULT_OS_TYPE=rancheros
 # 必要なミドルウェアを全てインストール
 yum makecache fast || _motd fail
 yum -y install curl docker jq || _motd fail
+
+# docker execできないバグ回避のためダウングレード
+yum downgrade -y docker-1.13.1-75.git8633870.el7.centos.x86_64 \
+                 docker-client-1.13.1-75.git8633870.el7.centos.x86_64 \
+                 docker-common-1.13.1-75.git8633870.el7.centos.x86_64
+
 systemctl enable docker.service || _motd fail
 systemctl start docker.service || _motd fail
 


### PR DESCRIPTION
yumでDockerをインストールすると`docker exec`でエラーが発生するようになっています。

参考: https://bugzilla.redhat.com/show_bug.cgi?id=1655214

このため、暫定的にdockerをダウングレードする処理を追加しました。