### PR TITLE
Rancher2セットアップ: dockerダウングレード処理の除去

### DIFF
--- a/publicscript/rancher2_setup/rancher2_setup.sh
+++ b/publicscript/rancher2_setup/rancher2_setup.sh
@@ -58,12 +58,6 @@ DEFAULT_OS_TYPE=rancheros
 # 必要なミドルウェアを全てインストール
 yum makecache fast || _motd fail
 yum -y install curl docker jq || _motd fail
-
-# docker execできないバグ回避のためダウングレード
-yum downgrade -y docker-1.13.1-75.git8633870.el7.centos.x86_64 \
-                 docker-client-1.13.1-75.git8633870.el7.centos.x86_64 \
-                 docker-common-1.13.1-75.git8633870.el7.centos.x86_64
-
 systemctl enable docker.service || _motd fail
 systemctl start docker.service || _motd fail
 


### PR DESCRIPTION
#123 の原因となった`docker exec`が実行できない問題に対応する更新版RPMパッケージがリリースされています。

参考: https://access.redhat.com/errata/RHBA-2018:3796

既にCentOSで利用できるようになっているため、ダウングレード処理を除去しました。