### PR TITLE
mastodon.sh で gem update --system を実行するように変更

### DIFF
--- a/publicscript/mastodon/mastodon.sh
+++ b/publicscript/mastodon/mastodon.sh
@@ -9,7 +9,7 @@
 # 事前に以下が必要です
 # ・さくらのクラウドDNSにゾーン登録
 # ・さくらのクラウドAPIのアクセストークンを取得
-# ブラウザからアクセスできるようになるまでの目安時間：30分
+# セットアップ目安時間：30分
 # セットアップ完了後サーバを自動で再起動します
 # https://(さくらのクラウドDNSのゾーン名)
 # @sacloud-desc-end
@@ -64,9 +64,9 @@ if [ $(echo "${RECODES}" | egrep -c "^(\[\]|null)$") -ne 1 ]
 then
 	if [ "${RECODES}x" = "x" ]
 	then
-		echo "ドメインのリソースIDが取得できません"
+		echo "ドメインのリソースIDが取得不可"
 	else
-		echo "レコードを登録していないドメインを指定してください"
+		echo "レコードを未登録のドメインを指定してください"
 	fi
 	_motd fail
 fi
@@ -310,7 +310,7 @@ ${CPATH}/certbot-auto -n certonly --webroot -w ${WROOT} -d ${DOMAIN} -m ${MADDR}
 
 if [ ! -f ${CERT} ]
 then
-	echo "証明書の取得に失敗しました"
+	echo "証明書の取得に失敗"
 	_motd fail
 fi
 
@@ -328,7 +328,7 @@ curl -s --user "${KEY}" -X PUT -d "$(cat ${PTRJS} | jq -c .)" ${API}
 RET=$(curl -s --user "${KEY}" -X GET ${API} | jq -r "select(.IPAddress.HostName == \"${DOMAIN}\") | .is_ok")
 if [ "${RET}x" != "truex" ]
 then
-	echo "逆引きの登録に失敗しました"
+	echo "逆引き登録に失敗"
 	_motd fail
 fi
 

--- a/publicscript/mastodon/mastodon.sh
+++ b/publicscript/mastodon/mastodon.sh
@@ -107,6 +107,7 @@ rbenv install \${RV}
 rbenv global \${RV}
 rbenv rehash
 cd live
+gem update --system
 gem install bundler -v \$(cat Gemfile.lock|grep -A 1 'BUNDLED WITH'|tail -n 1)
 bundle install --deployment --without development test
 yarn install --pure-lockfile


### PR DESCRIPTION
[最新のインストール方法](https://source.joinmastodon.org/mastodon/docs/blob/3411eb94d3c3b9225e1ca47f1b67969be7144f6a/content/en/administration/installation.md#L191)に合わせました。
また、現時点の Mastodon の .ruby-version では Ruby 2.6.1 がインストールされますが、[こちらの問題](https://bugs.ruby-lang.org/issues/15582)が存在するので、その解決のためにも必要となります。