### PR TITLE
vuls の GOVERSION を 1.12.9 に変更

### DIFF
--- a/publicscript/vuls/vuls.sh
+++ b/publicscript/vuls/vuls.sh
@@ -20,7 +20,7 @@
 set -x
 
 # Install requirements
-GOVERSION=1.9.4
+GOVERSION=1.12.9
 yum install -y yum-plugin-changelog yum-utils sqlite git gcc make
 curl -O https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz
 tar -C /usr/local/ -xzf go${GOVERSION}.linux-amd64.tar.gz


### PR DESCRIPTION
GO111MODULE=on への対応のため Go のバージョンを更新しました。
本スクリプトを使用し、問題なく実行できることを検証済みです。