### PR TITLE
mattermost のコマンド名を platform から mattermost に修正

### DIFF
--- a/publicscript/mattermost/mattermost.sh
+++ b/publicscript/mattermost/mattermost.sh
@@ -214,14 +214,15 @@ sed -i -e 's/dockerhost/127.0.0.1/' \
 cat <<_EOF_> /etc/systemd/system/mattermost.service
 [Unit]
 Description=Mattermost
-After=mysqld.service postfix.service
+After=network.target mysqld.service postfix.service
 
 [Service]
-Type=simple
-WorkingDirectory=/opt/mattermost/bin
+Type=notify
+WorkingDirectory=/opt/mattermost
 User=mattermost
-ExecStart=/opt/mattermost/bin/platform
+ExecStart=/opt/mattermost/bin/mattermost
 PIDFile=/var/spool/mattermost/pid/master.pid
+TimeoutStartSec=3600
 LimitNOFILE=49152
 
 [Install]

--- a/publicscript/mattermost/mattermost_spec.rb
+++ b/publicscript/mattermost/mattermost_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 services = %w(nginx mysqld mattermost postfix)
-processes = %w(nginx mysqld platform master)
+processes = %w(nginx mysqld mattermost master)
 ports = %w(25 80 443 8065)
 logchk = 'ls /root/.sacloud-api/notes/[0-9]*.done'
 
@@ -27,4 +27,3 @@ end
 describe command(logchk) do
   its(:stdout) { should match /done$/ }
 end
-


### PR DESCRIPTION
以下の変更を行ったのち、実際にスタートアップスクリプトを実行し、正常に動作することを確認しました。
また、rspec もすべてグリーンとなることを確認しています。

* [こちら](https://github.com/mattermost/docs/blob/92fa22e75fd8a20fd8cf2929a7abeb1ebc70de6b/source/administration/command-line-tools.rst#mattermost-36-and-later)の注に基づき `platform` ではなく `mattermost` コマンドを実行するように変更しました。
* [こちら](https://github.com/mattermost/docs/blob/92fa22e75fd8a20fd8cf2929a7abeb1ebc70de6b/source/install/install-rhel-7-mattermost.rst)の内容に基づき `/etc/systemd/system/mattermost.service` のいくつかの項目を更新しました。