### PR TITLE
依存する gem の Ruby のバージョン指定に対応するため install-redhat-td-agent2.5.sh に変更

### DIFF
--- a/publicscript/kibana/kibana.sh
+++ b/publicscript/kibana/kibana.sh
@@ -79,7 +79,7 @@ firewall-cmd --reload
 
 #===== Fluentd =====#
 echo "[*] Installing td-agent..."
-curl -L http://toolbelt.treasuredata.com/sh/install-redhat-td-agent2.sh | sh
+curl -L http://toolbelt.treasuredata.com/sh/install-redhat-td-agent2.5.sh | sh
 echo "[*] Installing td-agent-gem (fluent-plugin-elasticsearch)"
 td-agent-gem install fluent-plugin-elasticsearch
 


### PR DESCRIPTION
実際に本スクリプトを実行し、挙動に問題がないことを確認済みです。