### PR TITLE
ruby_on_rails.sh の Ruby のバージョンを更新

### DIFF
--- a/publicscript/ruby_on_rails/ruby_on_rails.sh
+++ b/publicscript/ruby_on_rails/ruby_on_rails.sh
@@ -4,15 +4,16 @@
 # @sacloud-once
 #
 # @sacloud-require-archive distro-centos distro-ver-6.*
+# @sacloud-require-archive distro-centos distro-ver-7.*
 #
 # @sacloud-desc-begin
 # rbenv、Bundler、Ruby on Rails をインストールするスクリプトです。
-# このスクリプトは、CentOS6.Xでのみ動作します。
+# このスクリプトは、CentOS 6.X, 7.X でのみ動作します。
 # このスクリプトは完了までに10分程度時間がかかります。
 # スクリプトの進捗状況は /root/.sacloud-api/notes/スタートアップスクリプトID.log をご確認ください。
 # @sacloud-desc-end
 # @sacloud-text required default="rbenv" shellarg user 'rbenv を利用するユーザー名'
-# @sacloud-text required default="2.3.0" shellarg ruby_version 'global で利用する Ruby のバージョン'
+# @sacloud-text required default="2.6.5" shellarg ruby_version 'global で利用する Ruby のバージョン'
 # @sacloud-checkbox default="1" shellarg create_gemrc 'gem の install と update 時に --no-document オプションを付与する .gemrc を作成する'
 
 # コントロールパネルの入力値を変数へ代入
@@ -32,16 +33,22 @@ if ! cat /etc/passwd | awk -F : '{ print $1 }' | egrep ^$user$; then
 fi
 
 echo "[1/5] Ruby のインストールに必要なライブラリをインストール中..."
-yum install -y openssl-devel  >/dev/null 2>&1
-yum install -y zlib-devel     >/dev/null 2>&1
-yum install -y readline-devel >/dev/null 2>&1
-yum install -y libyaml-devel  >/dev/null 2>&1
-yum install -y libffi-devel   >/dev/null 2>&1
+# https://github.com/rbenv/ruby-build/wiki#suggested-build-environment
+yum install -y gcc-6
+yum install -y bzip2
+yum install -y openssl-devel
+yum install -y libyaml-devel
+yum install -y libffi-devel
+yum install -y readline-devel
+yum install -y zlib-devel
+yum install -y gdbm-devel
+yum install -y ncurses-devel
+
 echo "[1/5] Ruby のインストールに必要なライブラリをインストールしました"
 
 echo "[2/5] rbenv をインストール中..."
-git clone https://github.com/sstephenson/rbenv.git      $home/.rbenv                    >/dev/null 2>&1
-git clone https://github.com/sstephenson/ruby-build.git $home/.rbenv/plugins/ruby-build >/dev/null 2>&1
+git clone https://github.com/sstephenson/rbenv.git      $home/.rbenv
+git clone https://github.com/sstephenson/ruby-build.git $home/.rbenv/plugins/ruby-build
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> $home/.bash_profile
 echo 'eval "$(rbenv init -)"'               >> $home/.bash_profile
 chown -R $user:$user $home/.rbenv
@@ -57,17 +64,17 @@ __EOS__
 fi
 
 echo "[3/5] Ruby のインストール中..."
-su -l $user -c "rbenv install $ruby_version" >/dev/null 2>&1
+su -l $user -c "rbenv install $ruby_version"
 su -l $user -c "rbenv global  $ruby_version"
 su -l $user -c "rbenv rehash"
 echo "[3/5] Ruby をインストールしました"
 
 echo "[4/5] Bundler のインストール中..."
-su -l $user -c "rbenv exec gem i bundler" >/dev/null 2>&1
+su -l $user -c "rbenv exec gem i bundler"
 echo "[4/5] Bundler をインストールしました"
 
 echo "[5/5] Rails のインストール中..."
-su -l $user -c "rbenv exec gem i rails" >/dev/null 2>&1
+su -l $user -c "rbenv exec gem i rails"
 echo "[5/5] Rails をインストールしました"
 
 echo "スタートアップスクリプトの処理が完了しました"


### PR DESCRIPTION
ruby_on_rails.sh に以下の修正をしました。

* デフォルトの Ruby のバージョンを 2.3.0 から 2.6.5 に更新しました。
* CentOS 7 でも動作を確認済みとしました。
* https://github.com/rbenv/ruby-build/wiki#suggested-build-environment を参考に yum でインストールするパッケージの見直しを行いました。

CentOS 6 と CentOS 7 で本スクリプトに問題がないことを確認済みです。