### PR TITLE
CentOS 8 対応の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@
 | --- | --- | :--- |
 | 設定支援 | [lb-dsr](./publicscript/lb-dsr/lb-dsr.sh) | ロードバランス対象のサーバの初期設定を自動化するためのスクリプトです。<br />このスクリプトは、以下のアーカイブでのみ動作します<br />- CentOS 6.X<br />- CentOS 7.X |
 | 設定支援 | [switching consoles for RancherOS](./publicscript/switching_consoles_for_rancheros/switching_consoles_for_rancheros.yml) | Rancher OSの標準のコンソールを設定するサンプルスクリプトです<br />このスクリプトは、以下のアーカイブでのみ動作します<br />- RancherOS |
-| CLI | [Usacloud](./publicscript/usacloud/usacloud.sh) | さくらのクラウドをコマンドラインで操作する [Usacloud](https://github.com/sacloud/usacloud)  をインストールします。[Usacloud](https://github.com/sacloud/usacloud)  は、さくらインターネット公認のユーザーコミュニティが開発を進めているツールです 。<br />※CentOS7系のみで動作します |
-| CLI | [Terraform for さくらのクラウド](./publicscript/terraform_for_sacloud/terraform_for_sacloud.sh) | インフラ構築や構成変更をコードで管理する“Infrastructure as Code“を実現するための、オープンソースのコマンドラインツール「Terraform」およびさくらのクラウドを利用するためのプラグインを一括でインストールします。詳細は「[Terraform for さくらのクラウド](https://cloud-news.sakura.ad.jp/startup-script/terraform-for-sakuracloud/)」をご確認ください。<br />※CentOS7系のみで動作します |
+| CLI | [Usacloud](./publicscript/usacloud/usacloud.sh) | さくらのクラウドをコマンドラインで操作する [Usacloud](https://github.com/sacloud/usacloud)  をインストールします。[Usacloud](https://github.com/sacloud/usacloud)  は、さくらインターネット公認のユーザーコミュニティが開発を進めているツールです 。<br />※CentOS 7.X, 8.X で動作します |
+| CLI | [Terraform for さくらのクラウド](./publicscript/terraform_for_sacloud/terraform_for_sacloud.sh) | インフラ構築や構成変更をコードで管理する“Infrastructure as Code“を実現するための、オープンソースのコマンドラインツール「Terraform」およびさくらのクラウドを利用するためのプラグインを一括でインストールします。詳細は「[Terraform for さくらのクラウド](https://cloud-news.sakura.ad.jp/startup-script/terraform-for-sakuracloud/)」をご確認ください。<br />※CentOS 7.X, 8.X で動作します |
 
 
 ## <a name="admin">システム管理・運用</a>
 
 | 分類 | 名前 | 説明 |
 | --- | --- | :--- |
-| パッケージ管理 | [yum update](./publicscript/yum_update/yum_update.sh) | サーバ作成後の初回起動時のみ、コマンド”yum update”を実行します。実行完了後、サーバが再起動されます。<br />※CentOS6系のみで動作します |
+| パッケージ管理 | [yum update](./publicscript/yum_update/yum_update.sh) | サーバ作成後の初回起動時のみ、コマンド”yum update”を実行します。実行完了後、サーバが再起動されます。<br />※CentOS 6.X, 7.X, 8.X で動作します |
 | パッケージ管理 | [apt-get update/upgrade](./publicscript/apt-get_update_upgrade/apt-get_update_upgrade.sh) | サーバ作成後の初回起動時のみ、コマンド”apt-get update”および”apt-get upgrade”を実行します。実行完了後、サーバが再起動されます。<br />※DebianまたはUbuntuのみで動作します |
 | コンテナ管理 | [Rancher2セットアップ](./publicscript/rancher2_setup/rancher2_setup.sh) | Rancher サーバとウェブ UI を自動的にセットアップするスクリプトです。ui-driver-sakuracloud がセットアップされ、さくらのクラウド上で Kubernetes クラスタを素早くセットアップできます。<br />※CentOS7系のみで動作します |
 | 監視 | [zabbix-server](./publicscript/zabbix-server/zabbix-server.sh) | 監視サーバであるzabbix-serverをインストールします。<br />本スクリプトの詳細は[マニュアル](https://cloud-news.sakura.ad.jp/startup-script/zabbix-server/)を参照ください。<br />※CentOS7系のみで動作します |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 | ECプラットフォーム | [Magento](./publicscript/magento/magento.sh) | 越境ECプラットフォームであるMagentoをインストールします。<br />本スクリプトの詳細は[マニュアル](https://cloud-news.sakura.ad.jp/startup-script/magento/)を参照ください。<br />※Ubuntu 18.04 のみで動作します |
 | SNS | [Mastodon](./publicscript/mastodon/mastodon.sh) | Twitterライクな投稿ができる分散型ソーシャルネットワーク「Mastodon」のインスタンス（サーバ）をセットアップします。<br />※CentOS7系のみで動作します |
 | コミュニケーション | [Mattermost](./publicscript/mattermost/mattermost.sh) | オープンソースのチャット型コミュニケーションツール「 [Mattermost](https://github.com/mattermost/platform/blob/master/README.md) 」サーバや MySQL、DNS を同時にセットアップします。<br />※ CentOS7 系のみで動作します |
-| 科学計算 | [Jupyter Notebook](./publicscript/jupyter_notebook/jupyter_notebook.sh) | データサイエンス環境としてAnacondaとウェブブラウザ上から手軽にプログラムを実行できるJupyter Notebookを一括でセットアップすることの出来るスタートアップスクリプトです。<br />インストール内容の詳細などは[SlideShare](https://www.slideshare.net/sakura_pr/sakura-cloud-startup-script-jupyter-notebook)をご参照ください。<br />※CentOS7系のみで動作します |
+| 科学計算 | [Jupyter Notebook](./publicscript/jupyter_notebook/jupyter_notebook.sh) | データサイエンス環境としてAnacondaとウェブブラウザ上から手軽にプログラムを実行できるJupyter Notebookを一括でセットアップすることの出来るスタートアップスクリプトです。<br />インストール内容の詳細などは[SlideShare](https://www.slideshare.net/sakura_pr/sakura-cloud-startup-script-jupyter-notebook)をご参照ください。<br />※CentOS 7.X, 8.X のみで動作します |
 | 分析基盤 | [kibana](./publicscript/kibana/kibana.sh) | 分析基盤としてElasticsearchとKibana、ログ収集のFluentdを一括しセットアップすることの出来るスタートアップスクリプトです。<br />インストール内容の詳細などは[SlideShare](https://www.slideshare.net/sakura_pr/sakura-cloudkibanaelasticsearchstartupscript)をご参照ください。<br />※CentOS7系のみで動作します |
 
 

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@
 | 監視 | [zabbix-agent](./publicscript/zabbix-agent/zabbix-agent.sh) | zabbix-serverに対応するエージェントzabbix-agentをインストールします。<br />本スクリプトの詳細は[マニュアル](https://cloud-news.sakura.ad.jp/startup-script/zabbix-agent/)を参照ください。<br />※CentOS7系のみで動作します |
 | セキュリティ | [SiteGuard Server Edition](./publicscript/siteguardlite/siteguardlite.sh) | WAF(Web Application Firewall)は、これまでのL3ファイアウォールでは防御することが難しかった、Web上で動作するアプリケーションなどのL7への攻撃検知・防御や、アクセス制御機構などを提供するものです。さくらのクラウドではJP-Secure社が開発する純国産のホスト型WAF製品「 SiteGuard Server Edition 」をさくらのクラウド向け特別版として無料で提供しています。<br />※CentOS系のみで動作します |
 | セキュリティ | [Vuls](./publicscript/vuls/vuls.sh) | オープンソースで開発が進められているLinux/FreeBSD向けの脆弱性スキャンツールです。OSだけでなくミドルウェアやプログラム言語のライブラリなどもスキャンに対応しております。また、エージェントレスで実行させることが出来、SSH経由でリモートのサーバのスキャンを行うことも可能です。<br />※CentOS7系のみで動作します |
-| RDP環境 | [GNOME-xrdp](./publicscript/xrdp/xrdp.sh) | GNOMEデスクトップ環境と xrdp をインストールします。Microsoftのリモートデスクトップなどを使用してサーバに接続することができます。<br />※CentOS7系のみで動作します |
+| RDP環境 | [GNOME-xrdp](./publicscript/xrdp/xrdp.sh) | GNOMEデスクトップ環境と xrdp をインストールします。Microsoftのリモートデスクトップなどを使用してサーバに接続することができます。<br />※CentOS 7.X, 8.X のみで動作します |

--- a/publicscript/jupyter_notebook/jupyter_notebook.sh
+++ b/publicscript/jupyter_notebook/jupyter_notebook.sh
@@ -4,10 +4,11 @@
 # @sacloud-once
 #
 # @sacloud-require-archive distro-centos distro-ver-7.*
+# @sacloud-require-archive distro-centos distro-ver-8.*
 #
 # @sacloud-desc-begin
 # pyenv, Anaconda,Jupyterをインストールするスクリプトです。
-# このスクリプトは、CentOS7.Xでのみ動作します。
+# このスクリプトは CentOS 7.X, 8.X でのみ動作します。
 # サーバ作成後、Webブラウザで以下のURL（サーバのIPアドレスと設定したポート）にアクセスしてください。
 #   http://サーバのIPアドレス:設定したポート/
 # アクセスした後、設定したJupyterのパスワードでログインしてください。

--- a/publicscript/ruby_on_rails/ruby_on_rails.sh
+++ b/publicscript/ruby_on_rails/ruby_on_rails.sh
@@ -5,10 +5,11 @@
 #
 # @sacloud-require-archive distro-centos distro-ver-6.*
 # @sacloud-require-archive distro-centos distro-ver-7.*
+# @sacloud-require-archive distro-centos distro-ver-8.*
 #
 # @sacloud-desc-begin
 # rbenv、Bundler、Ruby on Rails をインストールするスクリプトです。
-# このスクリプトは、CentOS 6.X, 7.X でのみ動作します。
+# このスクリプトは、CentOS 6.X, 7.X, 8.X でのみ動作します。
 # このスクリプトは完了までに10分程度時間がかかります。
 # スクリプトの進捗状況は /root/.sacloud-api/notes/スタートアップスクリプトID.log をご確認ください。
 # @sacloud-desc-end
@@ -34,7 +35,7 @@ fi
 
 echo "[1/5] Ruby のインストールに必要なライブラリをインストール中..."
 # https://github.com/rbenv/ruby-build/wiki#suggested-build-environment
-yum install -y gcc-6
+yum install -y gcc
 yum install -y bzip2
 yum install -y openssl-devel
 yum install -y libyaml-devel

--- a/publicscript/ruby_on_rails/ruby_on_rails.sh
+++ b/publicscript/ruby_on_rails/ruby_on_rails.sh
@@ -48,8 +48,8 @@ yum install -y ncurses-devel
 echo "[1/5] Ruby のインストールに必要なライブラリをインストールしました"
 
 echo "[2/5] rbenv をインストール中..."
-git clone https://github.com/sstephenson/rbenv.git      $home/.rbenv
-git clone https://github.com/sstephenson/ruby-build.git $home/.rbenv/plugins/ruby-build
+git clone https://github.com/rbenv/rbenv.git      $home/.rbenv
+git clone https://github.com/rbenv/ruby-build.git $home/.rbenv/plugins/ruby-build
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> $home/.bash_profile
 echo 'eval "$(rbenv init -)"'               >> $home/.bash_profile
 chown -R $user:$user $home/.rbenv

--- a/publicscript/terraform_for_sacloud/terraform_for_sacloud.sh
+++ b/publicscript/terraform_for_sacloud/terraform_for_sacloud.sh
@@ -3,11 +3,12 @@
 # @sacloud-name "Terraform for さくらのクラウド"
 # @sacloud-once
 # @sacloud-desc-begin
-#  CentOS7.xに Terraform for さくらのクラウド をインストールします
+#  CentOS 7.X, 8.X に「Terraform for さくらのクラウド」をインストールします
 #  インストール完了後にターミナルでサーバにログインし、terraformコマンドをご利用ください
 #  詳細はクラウドニュースを参照ください：https://cloud-news.sakura.ad.jp/startup-script/terraform-for-sakuracloud/
 # @sacloud-desc-end
 # @sacloud-require-archive distro-centos distro-ver-7.*
+# @sacloud-require-archive distro-centos distro-ver-8.*
 # @sacloud-select-begin required default=tk1v default_zone "Terraform for さくらのクラウドで操作するデフォルトゾーン"
 #   is1a "石狩第1ゾーン"
 #   is1b "石狩第2ゾーン"

--- a/publicscript/usacloud/usacloud.sh
+++ b/publicscript/usacloud/usacloud.sh
@@ -4,12 +4,13 @@
 # @sacloud-once
 # @sacloud-desc-begin
 # このスクリプトは usacloud をセットアップします
-# （このスクリプトは、CentOS7.X で動作します）
+# （このスクリプトは CentOS 7.X, 8.X で動作します）
 #
 # 事前作業として以下の1つが必要となります
 # ・さくらのクラウドAPIのアクセストークンを取得していること
 # @sacloud-desc-end
 # @sacloud-require-archive distro-centos distro-ver-7
+# @sacloud-require-archive distro-centos distro-ver-8
 # @sacloud-select-begin required default=default ZONE "操作対象ゾーンを選択してください。(defaultはサーバを作成したゾーンになります)
 #  default "default"
 #  is1a "is1a"

--- a/publicscript/yum_update/yum_update.sh
+++ b/publicscript/yum_update/yum_update.sh
@@ -3,9 +3,10 @@
 # @sacloud-name "yum update"
 # @sacloud-once
 # @sacloud-desc yum updateを実行します。完了後自動再起動します。
-# @sacloud-desc （このスクリプトは、CentOS6.X, 7.Xでのみ動作します）
+# @sacloud-desc （このスクリプトは CentOS 6.X, 7.X, 8.X でのみ動作します）
 # @sacloud-require-archive distro-centos distro-ver-6.*
 # @sacloud-require-archive distro-centos distro-ver-7.*
+# @sacloud-require-archive distro-centos distro-ver-8.*
 # @sacloud-checkbox default= noreboot "yum update完了後に再起動しない"
 
 yum -y update || exit 1


### PR DESCRIPTION
以下を CentOS 8 に対応

* yum_update.sh
* terraform_for_sacloud.sh
* usacloud.sh
* xrdp.sh
* jupyter_notebook.sh
* ruby_on_rails.sh