### PR TITLE
LAMPにシンプルモードに表示するロゴのタグ指定を追加

### DIFF
--- a/publicscript/lamp/lamp.sh
+++ b/publicscript/lamp/lamp.sh
@@ -13,7 +13,7 @@
 # @sacloud-require-archive distro-ubuntu distro-ver-18.04.*
 # @sacloud-require-archive distro-centos distro-ver-7.*
 # @sacloud-require-archive distro-centos distro-ver-6.*
-# @sacloud-tag @simplemode
+# @sacloud-tag @simplemode @logo-alphabet-l
 
 PASSWD=@@@mysql_password@@@
 


### PR DESCRIPTION
コンパネ側でシンプルモードのロゴ表示に用いるタグ( `@logo-alphabet-l` )を追加しました