### PR TITLE
Jitsui Meetスタートアップスクリプトの説明文を変更

### DIFF
--- a/publicscript/jitsi_meet/jitsi_meet.sh
+++ b/publicscript/jitsi_meet/jitsi_meet.sh
@@ -23,7 +23,7 @@
 #
 # @sacloud-desc-end
 # @sacloud-require-archive distro-ubuntu distro-ver-18.04*
-# @sacloud-text required DNS_ZONE "ホスト名（ドメインはDNSアプライアンスで管理されている必要があります）" ex="example.com"
+# @sacloud-text required DNS_ZONE "ゾーン名（ドメインは、さくらのクラウドのDNSアプライアンスに登録している必要があります）" ex="example.com"
 # @sacloud-apikey required permission=create API_KEY "APIキー"
 
 set -eux


### PR DESCRIPTION
フォームの記入欄に `ホスト名` とあると、FQDN や任意のホスト名を付与できると勘違いしてしまう可能性があるため、単純に `ドメイン名` と変更しました。いかがでしょうか。