### PR TITLE
Usacloud を v1.0系 にアップデート

### DIFF
--- a/publicscript/usacloud/usacloud.sh
+++ b/publicscript/usacloud/usacloud.sh
@@ -25,7 +25,7 @@ yum install -y yum-utils bash-completion
 yum-config-manager --enable epel
 yum install -y jq
 # usacloud install
-curl -fsSL http://releases.usacloud.jp/usacloud/repos/setup-yum.sh | sh
+curl -fsSL https://github.com/sacloud/usacloud/releases/latest/download/install.sh | sh
 # get zone name
 ZONE=@@@ZONE@@@
 if [ "${ZONE}" = "default" ]
@@ -33,7 +33,7 @@ then
   ZONE=$(jq -r ".Zone.Name" /root/.sacloud-api/server.json)
 fi
 # setup usacloud
-usacloud config --token ${SACLOUD_APIKEY_ACCESS_TOKEN}
-usacloud config --secret ${SACLOUD_APIKEY_ACCESS_TOKEN_SECRET}
-usacloud config --zone ${ZONE}
+usacloud config --token ${SACLOUD_APIKEY_ACCESS_TOKEN} --secret ${SACLOUD_APIKEY_ACCESS_TOKEN_SECRET} --zone ${ZONE} --default-output-type "table"
+# setup bash completion
+usacloud completion bash > /etc/bash_completion.d/usacloud
 exit 0


### PR DESCRIPTION
Usacloud のv1.0系へのメジャーバージョンアップに伴いいくつかの修正を行いました。

- インストールスクリプトのダウンロード元を`releases.usacloud.jp`からGitHub Releasesへ変更
- `usacloud config`でのAPIキー/ゾーン設定を1コマンドで行うように変更
- `usacloud config`でデフォルト出力形式(`--default-output-type`)の追加
   => 上記2つはv1.0以降`usacloud config`コマンドに未指定のパラメータがあった場合に入力待ちが発生するようになったことへの対応
- bash-completionの有効化
  => v1.0以降Usacloudのインストールスクリプト内でbash-completionの有効化処理が行われなくなったため

