### PR TITLE
GOのバージョンを 1.12.9 から 1.15.6 へ変更

### DIFF
--- a/publicscript/vuls/vuls.sh
+++ b/publicscript/vuls/vuls.sh
@@ -20,7 +20,7 @@
 set -x
 
 # Install requirements
-GOVERSION=1.12.9
+GOVERSION=1.15.6
 yum install -y yum-plugin-changelog yum-utils sqlite git gcc make
 curl -O https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz
 tar -C /usr/local/ -xzf go${GOVERSION}.linux-amd64.tar.gz


### PR DESCRIPTION
GOのバージョンが古くスタートアップスクリプトに失敗していた為、新しいバージョンへ変更しました。