### PR TITLE
Rancher2最新版が動作するように修正

### DIFF
--- a/publicscript/rancher2_setup/rancher2_setup.sh
+++ b/publicscript/rancher2_setup/rancher2_setup.sh
@@ -66,7 +66,6 @@ if [ "${ZONE}" = "default" ]; then
   ZONE=$(jq -r ".Zone.Name" /root/.sacloud-api/server.json)
 fi
 
-
 # ファイアウォールに対し http/https プロトコルでのアクセスを許可する
 firewall-cmd --permanent --add-service=http || _motd fail
 firewall-cmd --permanent --add-service=https || _motd fail
@@ -76,7 +75,8 @@ firewall-cmd --reload
 IP=`ip -f inet -o addr show eth0|cut -d\  -f 7 | cut -d/ -f 1`
 
 # Rancherサーバ起動
-docker run -d --restart=unless-stopped \
+docker run -d --privileged \
+              --restart=unless-stopped \
               -p 80:80 \
               -p 443:443 \
               -v /host/rancher:/var/lib/rancher \
@@ -114,7 +114,7 @@ docker exec rancher-server kubectl apply -f https://sacloud.github.io/ui-driver-
 sleep 5
 
 # ノードテンプレートの登録
-ADMIN_USER_NAME=`docker exec rancher-server kubectl get users.management.cattle.io -o "custom-columns=NAME:.metadata.name" --no-headers`
+ADMIN_USER_NAME=`docker exec rancher-server kubectl get users.management.cattle.io -o "custom-columns=NAME:.metadata.name" --no-headers | grep -Po 'user.+'`
 
 cat << EOS > nodeTemplate.yaml
 apiVersion: v1

--- a/publicscript/rancher2_setup/rancher2_setup.sh
+++ b/publicscript/rancher2_setup/rancher2_setup.sh
@@ -3,7 +3,7 @@
 # @sacloud-name "Rancher2セットアップ"
 # @sacloud-once
 #
-# @sacloud-require-archive distro-centos distro-ver-7.*
+# @sacloud-require-archive distro-centos distro-ver-7
 #
 # @sacloud-desc-begin
 #   さくらのクラウド上で Rancher サーバとウェブ UI を自動的にセットアップするスクリプトです。
@@ -11,6 +11,21 @@
 #   サーバ作成後、WebブラウザでサーバのIPアドレスにアクセスしてください。
 #   https://サーバのIPアドレス/
 #   (ユーザー名: admin, パスワード: 入力したRancher管理ユーザーのパスワード)
+#
+#  - 動作推奨環境 -
+# 
+#  デプロイサイズ (小)
+#  　　クラスタ数:　~ 5 まで
+#  　　ノード数:　~ 50 まで
+#  　　CPU:　1 コア 以上
+#  　　Memory:　4GB 以上
+#
+#  デプロイサイズ (中)
+#  　　クラスタ数: ~ 15 まで
+#  　　ノード数: ~ 200 まで
+#  　　CPU: 2 コア 以上
+#  　　Memory: 8 GB 以上
+#
 #   ※ セットアップには5分程度時間がかかります。
 #   （このスクリプトは、CentOS7.Xでのみ動作します）
 #   ※ 事前に「作成・削除」の権限を持つAPIキーの登録が必要です。
@@ -166,4 +181,3 @@ echo "Rancher server URL: ${RANCHER_SERVER}"
 echo "========================================================================="
 
 _motd end
-

--- a/publicscript/rancher2_setup/rancher2_setup.sh
+++ b/publicscript/rancher2_setup/rancher2_setup.sh
@@ -4,6 +4,9 @@
 # @sacloud-once
 #
 # @sacloud-require-archive distro-centos distro-ver-7
+# 
+# 動作環境 https://rancher.com/docs/rancher/v2.x/en/installation/requirements/#cpu-and-memory
+# @sacloud-tag @require-memory-gib>=4
 #
 # @sacloud-desc-begin
 #   さくらのクラウド上で Rancher サーバとウェブ UI を自動的にセットアップするスクリプトです。
@@ -11,20 +14,6 @@
 #   サーバ作成後、WebブラウザでサーバのIPアドレスにアクセスしてください。
 #   https://サーバのIPアドレス/
 #   (ユーザー名: admin, パスワード: 入力したRancher管理ユーザーのパスワード)
-#
-#  - 動作推奨環境 -
-# 
-#  デプロイサイズ (小)
-#  　　クラスタ数:　~ 5 まで
-#  　　ノード数:　~ 50 まで
-#  　　CPU:　1 コア 以上
-#  　　Memory:　4GB 以上
-#
-#  デプロイサイズ (中)
-#  　　クラスタ数: ~ 15 まで
-#  　　ノード数: ~ 200 まで
-#  　　CPU: 2 コア 以上
-#  　　Memory: 8 GB 以上
 #
 #   ※ セットアップには5分程度時間がかかります。
 #   （このスクリプトは、CentOS7.Xでのみ動作します）


### PR DESCRIPTION
Rancher2の最新版が動作するようにスタートスクリプトを修正しました。
`serverspec` のテストが通ることと、Rancher2上でWordPressをデプロイしてページが表示できる事を確認しました。

参考にしたURL：

推奨動作環境について
https://rancher.com/docs/rancher/v2.x/en/installation/requirements/#cpu-and-memory

`--privileged` オプションについて
https://rancher.com/docs/rancher/v2.x/en/installation/other-installation-methods/single-node-docker/

Rancher2上のクラスタ設定について
https://febc-yamamoto.hatenablog.jp/entry/sakura-rancher-startup-script