### PR TITLE
Docker for ubuntu

### DIFF
--- a/publicscript/docker_for_ubuntu/docker_for_ubuntu.sh
+++ b/publicscript/docker_for_ubuntu/docker_for_ubuntu.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # @sacloud-once
-# @sacloud-name "Docker Engine CE for Ubuntu"
-# @sacloud-desc Docker Engine Community Edition の最新安定版をインストールします。
+# @sacloud-name "Docker Engine for Ubuntu"
+# @sacloud-desc Docker Engine の最新安定版をインストールします。
 #
 # @sacloud-require-archive distro-ubuntu
 

--- a/publicscript/docker_for_ubuntu/docker_for_ubuntu.sh
+++ b/publicscript/docker_for_ubuntu/docker_for_ubuntu.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# @sacloud-once
+# @sacloud-name "Docker Engine CE for Ubuntu"
+# @sacloud-desc Docker Engine Community Edition の最新安定版をインストールします。
+#
+# @sacloud-require-archive distro-ubuntu
+
+_motd() {
+ LOG=$(ls /root/.sacloud-api/notes/*log)
+ case $1 in
+  start)
+   echo -e "\n#-- Startup-script is \\033[0;32mrunning\\033[0;39m. --#\n\nPlease check the log file: ${LOG}\n" > /etc/motd
+  ;;
+  fail)
+   echo -e "\n#-- Startup-script \\033[0;31mfailed\\033[0;39m. --#\n\nPlease check the log file: ${LOG}\n" > /etc/motd
+   exit 1
+  ;;
+  end)
+   cp -f /dev/null /etc/motd
+  ;;
+ esac
+}
+
+_motd start
+set -eux
+trap '_motd fail' ERR
+
+# Naviage to root direcotry.
+echo "* cd root dir"
+cd /root
+
+# Install Docker Engine.
+# Reference: https://docs.docker.com/engine/install/ubuntu/
+echo "* Uninstall old packages and install required tools"
+apt-get remove docker docker-engine docker.io containerd runc
+apt-get update
+apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+echo "* Add Docker's offical GPG key"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo \
+  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+echo "* Install Docker Engine"
+apt-get update
+apt-get install docker-ce docker-ce-cli containerd.io
+
+echo "* Start Docker service and setup to start it automatically at boot"
+systemctl start docker
+systemctl enable docker
+
+# 設定完了を表示
+echo "* Complete!"
+
+_motd end
+
+
+

--- a/publicscript/docker_for_ubuntu/docker_for_ubuntu.sh
+++ b/publicscript/docker_for_ubuntu/docker_for_ubuntu.sh
@@ -26,15 +26,13 @@ _motd start
 set -eux
 trap '_motd fail' ERR
 
-# Naviage to root direcotry.
-echo "* cd root dir"
+# Naviage to root directory.
 cd /root
 
-# Install Docker Engine.
 # Reference: https://docs.docker.com/engine/install/ubuntu/
-echo "* Uninstall old packages and install required tools"
+# Uninstall old packages and install required tools.
 apt-get remove docker docker-engine docker.io containerd runc || true
-apt-get update
+apt-get update && apt-get upgrade -y
 apt-get install -y \
         apt-transport-https \
         ca-certificates \
@@ -42,25 +40,29 @@ apt-get install -y \
         gnupg \
         lsb-release
 
-echo "* Add Docker's offical GPG key"
+# Add Docker's offical GPG key.
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
     gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-echo "* Install Docker Engine"
+# Install Docker Engine.
 apt-get update
-apt-get install -y docker-ce docker-ce-cli containerd.io
+apt-get install -y docker-ce-cli containerd.io
+# To avoid failed to start 'apt-get install -y docker-ce' only once.
+# Show the log below when runs 'apt-get install -y docker-ce' only once.
+# -- Logs begin at Wed 2021-05-26 13:21:37 JST, end at Wed 2021-05-26 13:44:04 JST. --
+# May 26 13:26:51 ubuntu systemd[1]: Starting Docker Application Container Engine...
+# May 26 13:26:52 ubuntu dockerd[35186]: time="2021-05-26T13:26:52.030098275+09:00" level=info msg="Starting up"
+# May 26 13:26:52 ubuntu dockerd[35186]: failed to load listeners: no sockets found via socket activation: make sure the service was started by systemd
+# May 26 13:26:52 ubuntu systemd[1]: docker.service: Main process exited, code=exited, status=1/FAILURE
+# May 26 13:26:52 ubuntu systemd[1]: docker.service: Failed with result 'exit-code'.
+# May 26 13:26:52 ubuntu systemd[1]: Failed to start Docker Application Container Engine.
+# May 26 13:26:54 ubuntu systemd[1]: docker.service: Scheduled restart job, restart counter is at 1.
+# May 26 13:26:54 ubuntu systemd[1]: Stopped Docker Application Container Engine.
+# May 26 13:26:54 ubuntu systemd[1]: Starting Docker Application Container Engine...
+apt-get install -y docker-ce || apt-get install -y docker-ce
 
-echo "* Start Docker service and setup to start it automatically at boot"
-systemctl start docker
-systemctl enable docker
-
-# 設定完了を表示
-echo "* Complete!"
-
+# Complete!
 _motd end
-
-
-

--- a/publicscript/docker_for_ubuntu/docker_for_ubuntu.sh
+++ b/publicscript/docker_for_ubuntu/docker_for_ubuntu.sh
@@ -33,14 +33,14 @@ cd /root
 # Install Docker Engine.
 # Reference: https://docs.docker.com/engine/install/ubuntu/
 echo "* Uninstall old packages and install required tools"
-apt-get remove docker docker-engine docker.io containerd runc
+apt-get remove docker docker-engine docker.io containerd runc || true
 apt-get update
-apt-get install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
+apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
 
 echo "* Add Docker's offical GPG key"
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
@@ -51,7 +51,7 @@ echo \
 
 echo "* Install Docker Engine"
 apt-get update
-apt-get install docker-ce docker-ce-cli containerd.io
+apt-get install -y docker-ce docker-ce-cli containerd.io
 
 echo "* Start Docker service and setup to start it automatically at boot"
 systemctl start docker

--- a/publicscript/docker_for_ubuntu/docker_for_ubuntu_spec.rb
+++ b/publicscript/docker_for_ubuntu/docker_for_ubuntu_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+services = %w(docker)
+processes = %w(dockerd)
+logchk = 'ls /root/.sacloud-api/notes/[0-9]*.done'
+services.each do |service_name|
+  describe service(service_name) do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+processes.each do |proc_name|
+  describe process(proc_name) do
+    it { should be_running }
+  end
+end
+describe command(logchk) do
+  its(:stdout) { should match /done$/ }
+end


### PR DESCRIPTION
## 概要
* Ubuntu（2021/05/26現在でリリースされている 18.01-5,20.04）にて、Dockerの安定版をインストールするスクリプト

## 確認した項目
* 対象のアーカイブにて当該スタートアップスクリプトを指定し、`/root/.sacloud-api/notes/スタートアップスクリプトID.log` のステータスコードが `0` であること
* docker_for_ubuntu_spec.rb を `serverspec-init` 後、 `./spec/localhost/docker_for_ubuntu_spec.rb` として配置し、`sudo rake spec` を実行し、 `0 failures` であることを確認