### PR TITLE
Jitsi MeetスクリプトがUbuntu 18.04 でインストールに失敗する問題の修正

### DIFF
--- a/publicscript/jitsi_meet/jitsi_meet.sh
+++ b/publicscript/jitsi_meet/jitsi_meet.sh
@@ -52,41 +52,39 @@ apt-get update
 dns_zone="@@@DNS_ZONE@@@"
 
 # さくらのクラウドを API で操作するため usacloud をインストール。
-# https://github.com/sacloud/usacloud/tree/ac47348d5200c5c5ce126f950d807ef45a01775d#macosbrew--linuxapt-or-yum-or-brew--bash-on-windowsubuntu
+# https://docs.usacloud.jp/usacloud/installation/start_guide/
 apt-get install -y curl gnupg2 jq
-curl -fsSL https://releases.usacloud.jp/usacloud/repos/install.sh | bash
+curl -fsSL https://github.com/sacloud/usacloud/releases/latest/download/install.sh | bash
 usacloud config --token "${SACLOUD_APIKEY_ACCESS_TOKEN}"
 usacloud config --secret "${SACLOUD_APIKEY_ACCESS_TOKEN_SECRET}"
 usacloud config --zone "$(jq -r .Zone.Name /root/.sacloud-api/server.json)"
 usacloud config --default-output-type "json"
 
 # usacloud でさくらのクラウドのDNSゾーンにリソースレコードを追加。
-dns_records_size="$(usacloud dns read ${dns_zone} | jq '.[0].Settings.DNS.ResourceRecordSets | length')"
+dns_records_size="$(usacloud dns read ${dns_zone} | jq '.[0].Records | length')"
 if [ "${dns_records_size}" != "0" ]; then
   echo "リソースレコードは未登録のままの状態にしておいてください。"
   exit 1
 fi
 
 ip_address=$(jq -r .Interfaces[0].IPAddress /root/.sacloud-api/server.json)
-usacloud dns record-add -y --name '@' --type 'A' --value "${ip_address}" "${dns_zone}"
+usacloud dns update ${dns_zone} -y --parameters '{"Records": [{ "Name": "@", "Type": "A", "RData": "'${ip_address}'" }]}'
 
 # jitsi-meet のインストール。
 # via https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-quickstart
-apt-get install -y apt-transport-https openjdk-8-jdk software-properties-common
+apt-get install -y nginx-full apt-transport-https openjdk-8-jdk software-properties-common
+
+apt-add-repository universe
 
 # Ubuntu 18.04 用に Prosody パッケージリポジトリの追加
 # via https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-quickstart#for-ubuntu-1804-add-prosody-package-repository
 if [[ $(lsb_release -rs) == "18.04" ]]; then
   echo deb http://packages.prosody.im/debian $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list
   wget https://prosody.im/files/prosody-debian-packages.key -O- | sudo apt-key add -
-  curl https://download.jitsi.org/jitsi-key.gpg.key | sudo sh -c 'gpg --dearmor > /usr/share/keyrings/jitsi-keyring.gpg'
-  echo 'deb [signed-by=/usr/share/keyrings/jitsi-keyring.gpg] https://download.jitsi.org stable/' | sudo tee /etc/apt/sources.list.d/jitsi-stable.list > /dev/null
-else
-  echo 'deb https://download.jitsi.org stable/' >> /etc/apt/sources.list.d/jitsi-stable.list
-  wget -qO - https://download.jitsi.org/jitsi-key.gpg.key | apt-key add -
-
-  apt-add-repository universe
 fi
+
+curl https://download.jitsi.org/jitsi-key.gpg.key | sudo sh -c 'gpg --dearmor > /usr/share/keyrings/jitsi-keyring.gpg'
+echo 'deb [signed-by=/usr/share/keyrings/jitsi-keyring.gpg] https://download.jitsi.org stable/' | sudo tee /etc/apt/sources.list.d/jitsi-stable.list > /dev/null
 
 apt-get update
 
@@ -94,4 +92,15 @@ apt-get update
 echo "jitsi-videobridge2 jitsi-videobridge/jvb-hostname string ${dns_zone}" | debconf-set-selections
 export DEBIAN_FRONTEND=noninteractive
 
+# ufw のセットアップ
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw allow 10000/udp
+ufw allow 22/tcp
+ufw allow 3478/udp
+ufw allow 5349/tcp
+ufw enable
+
 apt-get install -y jitsi-meet
+
+_motd end


### PR DESCRIPTION
# 概要

Jitsi Meet スタートアップスクリプトが Ubuntu 18.04 でインストールに失敗する問題の修正を行います。

# テスト方法とテスト結果

さくらのクラウド上の Ubuntu Server に修正後のスタートアップスクリプトを実行後、
serverspec にパスすることと Jitsi Meet ページを開いてビデオ通話が可能なことを確認しました。

Ubuntu Server 18.04 と 20.04 の両方で検証済みです。
