### PR TITLE
SiteGuard を 5.00 Update 1 に更新

### DIFF
--- a/publicscript/siteguardlite/siteguardlite.sh
+++ b/publicscript/siteguardlite/siteguardlite.sh
@@ -4,10 +4,11 @@
 # @sacloud-desc WAF(Web Application Firewall)は、これまでのL3ファイアウォールでは防御することが難しかった、Web上で動作するアプリケーションなどのL7への攻撃検知・防御や、アクセス制御機構などを提供するものです。
 # @sacloud-desc さくらのクラウドではEGセキュアソリューションズ株式会社が開発する純国産のホスト型WAF製品「SiteGuard Server Edition」をさくらのクラウド向け特別版として無料で提供しています。
 # @sacloud-desc 完了後自動再起動します。
-# @sacloud-desc （このスクリプトは CentOS 7.X, 8.X で動作します）
+# @sacloud-desc （このスクリプトは CentOS 7.X, 8.X, AlmaLinux 8.X で動作します）
 # @sacloud-desc セットアップ完了後、ご利用ガイド、管理者用ガイドを参照し初期設定を実施してください。
 # @sacloud-require-archive distro-centos distro-ver-7.*
 # @sacloud-require-archive distro-centos distro-ver-8.*
+# @sacloud-require-archive distro-alma distro-ver-8.*
 ## ScriptName : CentOS_SiteGuardServerEdition-Apache
 #===== Startup Script Motd Monitor =====#
 _motd() {
@@ -36,7 +37,7 @@ firewall-cmd --add-port=9443/tcp --zone=public --permanent
 firewall-cmd --reload
 
 yum install -y httpd glibc perl wget unzip openssl make file java mod_ssl expect
-file_name="siteguard-server-edition-5.00-0.apache.x86_64.rpm"
+file_name="siteguard-server-edition-5.00-1.apache.x86_64.rpm"
 wget -q "http://progeny.sakura.ad.jp/siteguard/5.0.0/apache/${file_name}" -P /root/.sakuracloud
 rpm -Uvh "/root/.sakuracloud/${file_name}"
 

--- a/publicscript/siteguardlite/siteguardlite.sh
+++ b/publicscript/siteguardlite/siteguardlite.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# @sacloud-name "SiteGuard Server Edition for CentOS"
+# @sacloud-name "SiteGuard Server Edition"
 # @sacloud-once
 # @sacloud-desc WAF(Web Application Firewall)は、これまでのL3ファイアウォールでは防御することが難しかった、Web上で動作するアプリケーションなどのL7への攻撃検知・防御や、アクセス制御機構などを提供するものです。
 # @sacloud-desc さくらのクラウドではEGセキュアソリューションズ株式会社が開発する純国産のホスト型WAF製品「SiteGuard Server Edition」をさくらのクラウド向け特別版として無料で提供しています。


### PR DESCRIPTION
## 概要
SiteGuard を5.00 Update 1  にアップデートしました。
また、今回から動作対象の OS（ディストリビューション）に AlmaLinux を追加しました。
ご確認よろしくお願いいたします。

追記：
スクリプト名から「for CentOS」の表記を削除しました。

## 動作確認

さくらのクラウド上でスクリプトを実行して、問題なく動作することを確認しました。

- Centos
- AlmaLinux

で動作確認済みです。

<details>
<summary>Centos</summary>
<img width="1676" alt="スクリーンショット 2022-04-21 12 30 24" src="https://user-images.githubusercontent.com/32587994/164370590-89603707-3a06-40b4-b834-a98c15876f74.png">
</details>

<details>
<summary>AlmaLinux</summary>
<img width="1676" alt="スクリーンショット 2022-04-21 12 48 26" src="https://user-images.githubusercontent.com/32587994/164370626-e4b85314-ed74-4980-aac7-1534a01b30e7.png">
</details>